### PR TITLE
Fix Redis URL and improve CSV export test

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ to launch the bot you only need a token bot, database and redis settings, everyt
 | name                     | description                                                                                 |
 | ------------------------ | ------------------------------------------------------------------------------------------- |
 | `BOT_TOKEN`              | Telegram bot API token                                                                      |
-| `RATE_LIMIT`             | Maximum number of requests allowed per minute for rate limiting                             |
+| `RATE_LIMIT`             | Minimum interval in seconds between requests for throttling middleware                      |
 | `DEBUG`                  | Enable or disable debugging mode (e.g., `True` or `False`)                                  |
 | `USE_WEBHOOK`            | Flag to indicate whether the bot should use a webhook for updates (e.g., `True` or `False`) |
 | `WEBHOOK_BASE_URL`       | Base URL for the webhook                                                                    |

--- a/admin/config.py
+++ b/admin/config.py
@@ -14,7 +14,7 @@ DEBUG: bool = str(os.getenv("DEBUG")).lower() == "true"
 
 BABEL_DEFAULT_LOCALE = os.getenv("BABEL_DEFAULT_LOCALE") or "en"
 
-# Create dummy secrey key so we can use sessions
+# Create dummy secret key so we can use sessions
 SECRET_KEY: str = os.getenv("SECRET_KEY") or "x%#3&%giwv8f0+%r946en7z&d@9*rc$sl0qoql56xr%bh^w2mj"
 
 

--- a/bot/core/config.py
+++ b/bot/core/config.py
@@ -72,7 +72,7 @@ class CacheSettings(EnvBaseSettings):
     @property
     def redis_url(self) -> str:
         if self.REDIS_PASS:
-            return f"redis://{self.REDIS_PASS}@{self.REDIS_HOST}:{self.REDIS_PORT}/0"
+            return f"redis://:{self.REDIS_PASS}@{self.REDIS_HOST}:{self.REDIS_PORT}/0"
         return f"redis://{self.REDIS_HOST}:{self.REDIS_PORT}/0"
 
 

--- a/bot/utils/users_export.py
+++ b/bot/utils/users_export.py
@@ -10,12 +10,14 @@ from bot.database.models import UserModel
 
 async def convert_users_to_csv(users: list[UserModel]) -> BufferedInputFile:
     """Export all users in csv file."""
-    columns = UserModel.__table__.columns
+    columns = list(UserModel.__table__.columns)
+    headers = [column.name for column in columns]
     data = [[getattr(user, column.name) for column in columns] for user in users]
 
     s = io.StringIO()
-    csv.writer(s).writerow(columns)
-    csv.writer(s).writerows(data)
+    writer = csv.writer(s)
+    writer.writerow(headers)
+    writer.writerows(data)
     s.seek(0)
 
     return BufferedInputFile(

--- a/tests/test_users_export.py
+++ b/tests/test_users_export.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+import asyncio
+import csv
+import io
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Generic, TypeVar
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+sqlalchemy_stub = types.ModuleType("sqlalchemy")
+sqlalchemy_stub.BigInteger = int
+
+
+def _text(value: str) -> str:
+    return value
+
+
+sqlalchemy_stub.text = _text
+orm_stub = types.ModuleType("sqlalchemy.orm")
+_T = TypeVar("_T")
+
+
+class _DeclarativeBase:  # pragma: no cover - stub class
+    pass
+
+
+def _mapped_column(*args: object, **kwargs: object) -> None:  # pragma: no cover - stub function
+    return None
+
+
+class _Mapped(Generic[_T]):  # pragma: no cover - stub class
+    pass
+
+
+orm_stub.DeclarativeBase = _DeclarativeBase
+orm_stub.Mapped = _Mapped
+orm_stub.mapped_column = _mapped_column
+sqlalchemy_stub.orm = orm_stub
+sys.modules.setdefault("sqlalchemy", sqlalchemy_stub)
+sys.modules.setdefault("sqlalchemy.orm", orm_stub)
+
+aiogram_stub = types.ModuleType("aiogram")
+types_stub = types.ModuleType("aiogram.types")
+
+
+class _BufferedInputFile:  # pragma: no cover - stub class
+    def __init__(self, *, file: bytes, filename: str) -> None:
+        self.file = file
+        self.filename = filename
+
+
+types_stub.BufferedInputFile = _BufferedInputFile
+aiogram_stub.types = types_stub
+sys.modules.setdefault("aiogram", aiogram_stub)
+sys.modules.setdefault("aiogram.types", types_stub)
+
+from bot.utils.users_export import convert_users_to_csv  # noqa: E402
+
+
+class DummyColumn:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class DummyUserModel:
+    column_names = [
+        "id",
+        "first_name",
+        "last_name",
+        "username",
+        "language_code",
+        "referrer",
+        "created_at",
+        "is_admin",
+        "is_suspicious",
+        "is_block",
+        "is_premium",
+    ]
+    __table__ = types.SimpleNamespace(columns=[DummyColumn(name) for name in column_names])
+
+    def __init__(self, **kwargs: object) -> None:
+        for column in self.__table__.columns:
+            setattr(self, column.name, kwargs.get(column.name))
+
+
+convert_users_to_csv.__globals__["UserModel"] = DummyUserModel
+
+
+def test_convert_users_to_csv_writes_column_names() -> None:
+    user = DummyUserModel(
+        id=1,
+        first_name="Alice",
+        last_name=None,
+        username="alice",
+        language_code="en",
+        referrer=None,
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        is_admin=False,
+        is_suspicious=False,
+        is_block=False,
+        is_premium=True,
+    )
+
+    csv_file = asyncio.run(convert_users_to_csv([user]))
+
+    content = csv_file.file.decode("utf-8")
+    rows = list(csv.reader(io.StringIO(content)))
+    expected_header = [column.name for column in DummyUserModel.__table__.columns]
+
+    assert rows[0] == expected_header
+    assert rows[1][expected_header.index("first_name")] == "Alice"


### PR DESCRIPTION
## Summary
- fix the typo in the admin config comment for the secret key
- ensure the Redis URL includes the required colon when a password is set and align the README description of `RATE_LIMIT`
- write CSV headers using column names and add a regression test for `convert_users_to_csv`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca871d0c20832a9d21f9818c335095